### PR TITLE
updates hook containers name

### DIFF
--- a/lib/octopress-minify-html.rb
+++ b/lib/octopress-minify-html.rb
@@ -32,16 +32,16 @@ module Octopress
       return obj.reduce({}) do |memo, (k, v)|
         memo.tap { |m| m[k.to_sym] = symbolize(v) }
       end if obj.is_a? Hash
-        
-      return obj.reduce([]) do |memo, v| 
+
+      return obj.reduce([]) do |memo, v|
         memo << symbolize(v); memo
       end if obj.is_a? Array
-      
+
       obj
     end
 
     if defined?(Jekyll::Hooks)
-      Jekyll::Hooks.register [:post, :page, :document], :post_render do |item|
+      Jekyll::Hooks.register [:posts, :pages, :documents], :post_render do |item|
         item.output = MinifyHTML.minify(item)
       end
     else


### PR DESCRIPTION
Not minify HTML in Jekyll 3.0.0, since the hook container names are broken. This PR fixes this.
