### PR TITLE
Support for Jekyll 3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 1.3.1 (2016-02-04)
+- New: Support for Jekyll 3.1.
+
 ### 1.3.0 (2015-07-07)
 - New: Support for Jekyll 3.
 

--- a/lib/octopress-minify-html.rb
+++ b/lib/octopress-minify-html.rb
@@ -41,7 +41,7 @@ module Octopress
     end
 
     if defined?(Jekyll::Hooks)
-      Jekyll::Hooks.register [:post, :page, :document], :post_render do |item|
+      Jekyll::Hooks.register [:posts, :pages, :documents], :post_render do |item|
         item.output = MinifyHTML.minify(item)
       end
     else

--- a/lib/octopress-minify-html/version.rb
+++ b/lib/octopress-minify-html/version.rb
@@ -1,5 +1,5 @@
 module Octopress
   module MinifyHTML
-    VERSION = "1.3.0"
+    VERSION = "1.3.1"
   end
 end


### PR DESCRIPTION
Jekyll 3.1 has renamed post->posts, page->pages, document->documents. Updated code for that.
